### PR TITLE
`GoRename' integration improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+package-metadata.json

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -182,5 +182,9 @@
 			{ "key": "selector", "operator": "equal", "operand": "prompt.9o" },
 			{ "key": "auto_complete_visible", "operand": false }
 		]
-	}
+	},
+    {
+        "keys": ["ctrl+shift+r"],
+        "command": "gs_gorename"
+    }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -176,5 +176,9 @@
 			{ "key": "selector", "operator": "equal", "operand": "prompt.9o" },
 			{ "key": "auto_complete_visible", "operand": false }
 		]
-	}
+	},
+    {
+        "keys": ["super+shift+r"],
+        "command": "gs_gorename"
+    }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -182,5 +182,9 @@
 			{ "key": "selector", "operator": "equal", "operand": "prompt.9o" },
 			{ "key": "auto_complete_visible", "operand": false }
 		]
-	}
+	},
+    {
+        "keys": ["ctrl+shift+r"],
+        "command": "gs_gorename"
+    }
 ]

--- a/gosubl/about.py
+++ b/gosubl/about.py
@@ -2,7 +2,7 @@ import re
 import sublime
 
 ANN = 'a14.02.25-1'
-VERSION = 'r13.12.26-3'
+VERSION = 'r14.12.06-1'
 VERSION_PAT = re.compile(r'\d{2}[.]\d{2}[.]\d{2}-\d+', re.IGNORECASE)
 DEFAULT_GO_VERSION = 'go?'
 GO_VERSION_OUTPUT_PAT = re.compile(r'go\s+version\s+(\S+(?:\s+[+]\w+|\s+\([^)]+)?)', re.IGNORECASE)

--- a/gscommands.py
+++ b/gscommands.py
@@ -4,267 +4,275 @@ from gosubl import mg9
 import datetime
 import subprocess
 import os
+import pipes
+import platform
 import sublime
 import sublime_plugin
 
 DOMAIN = 'GoSublime'
 
 class GsCommentForwardCommand(sublime_plugin.TextCommand):
-	def run(self, edit):
-		self.view.run_command("toggle_comment", {"block": False})
-		self.view.run_command("move", {"by": "lines", "forward": True})
+    def run(self, edit):
+        self.view.run_command('toggle_comment', {'block': False})
+        self.view.run_command('move', {'by': 'lines', 'forward': True})
 
 class GsStartNextLineCommentCommand(sublime_plugin.TextCommand):
-	def run(self, edit):
-		self.view.run_command("run_macro_file", {"file": "Packages/Default/Add Line.sublime-macro"})
-		self.view.run_command("toggle_comment", {"block": False})
+    def run(self, edit):
+        self.view.run_command('run_macro_file', {'file': 'Packages/Default/Add Line.sublime-macro'})
+        self.view.run_command('toggle_comment', {'block': False})
 
 class GsFmtCommand(sublime_plugin.TextCommand):
-	def is_enabled(self):
-		fn = self.view.file_name()
-		if fn:
-			scope_ok = fn.lower().endswith('.go')
-		else:
-			scope_ok = gs.is_go_source_view(self.view)
+    def is_enabled(self):
+        fn = self.view.file_name()
+        if fn:
+            scope_ok = fn.lower().endswith('.go')
+        else:
+            scope_ok = gs.is_go_source_view(self.view)
 
-		return scope_ok and gs.setting('fmt_enabled') is True
+        return scope_ok and gs.setting('fmt_enabled') is True
 
-	def run(self, edit):
-		vsize = self.view.size()
-		src = self.view.substr(sublime.Region(0, vsize))
-		if not src.strip():
-			return
+    def run(self, edit):
+        vsize = self.view.size()
+        src = self.view.substr(sublime.Region(0, vsize))
+        if not src.strip():
+            return
 
-		src, err = mg9.fmt(self.view.file_name(), src)
-		if err:
-			gs.println(DOMAIN, "cannot fmt file. error: `%s'" % err)
-			return
+        src, err = mg9.fmt(self.view.file_name(), src)
+        if err:
+            gs.println(DOMAIN, 'cannot fmt file. error: `%s\'' % err)
+            return
 
-		if not src.strip():
-			gs.println(DOMAIN, "cannot fmt file. it appears to be empty")
-			return
+        if not src.strip():
+            gs.println(DOMAIN, 'cannot fmt file. it appears to be empty')
+            return
 
-		_, err = gspatch.merge(self.view, vsize, src, edit)
-		if err:
-			msg = 'PANIC: Cannot fmt file. Check your source for errors (and maybe undo any changes).'
-			sublime.error_message("%s: %s: Merge failure: `%s'" % (DOMAIN, msg, err))
+        _, err = gspatch.merge(self.view, vsize, src, edit)
+        if err:
+            msg = 'PANIC: Cannot fmt file. Check your source for errors (and maybe undo any changes).'
+            sublime.error_message('%s: %s: Merge failure: `%s\'' % (DOMAIN, msg, err))
 
 class GsFmtSaveCommand(sublime_plugin.TextCommand):
-	def is_enabled(self):
-		return gs.is_go_source_view(self.view)
+    def is_enabled(self):
+        return gs.is_go_source_view(self.view)
 
-	def run(self, edit):
-		self.view.run_command("gs_fmt")
-		sublime.set_timeout(lambda: self.view.run_command("save"), 0)
+    def run(self, edit):
+        self.view.run_command('gs_fmt')
+        sublime.set_timeout(lambda: self.view.run_command('save'), 0)
 
 class GsFmtPromptSaveAsCommand(sublime_plugin.TextCommand):
-	def is_enabled(self):
-		return gs.is_go_source_view(self.view)
+    def is_enabled(self):
+        return gs.is_go_source_view(self.view)
 
-	def run(self, edit):
-		self.view.run_command("gs_fmt")
-		sublime.set_timeout(lambda: self.view.run_command("prompt_save_as"), 0)
+    def run(self, edit):
+        self.view.run_command('gs_fmt')
+        sublime.set_timeout(lambda: self.view.run_command('prompt_save_as'), 0)
 
 class GsGotoRowColCommand(sublime_plugin.TextCommand):
-	def run(self, edit, row, col=0):
-		pt = self.view.text_point(row, col)
-		r = sublime.Region(pt, pt)
-		self.view.sel().clear()
-		self.view.sel().add(r)
-		self.view.show(pt)
-		dmn = 'gs.focus.%s:%s:%s' % (gs.view_fn(self.view), row, col)
-		flags = sublime.DRAW_EMPTY_AS_OVERWRITE
-		show = lambda: self.view.add_regions(dmn, [r], 'comment', 'bookmark', flags)
-		hide = lambda: self.view.erase_regions(dmn)
+    def run(self, edit, row, col=0):
+        pt = self.view.text_point(row, col)
+        r = sublime.Region(pt, pt)
+        self.view.sel().clear()
+        self.view.sel().add(r)
+        self.view.show(pt)
+        dmn = 'gs.focus.%s:%s:%s' % (gs.view_fn(self.view), row, col)
+        flags = sublime.DRAW_EMPTY_AS_OVERWRITE
+        show = lambda: self.view.add_regions(dmn, [r], 'comment', 'bookmark', flags)
+        hide = lambda: self.view.erase_regions(dmn)
 
-		for i in range(3):
-			m = 300
-			s = i * m * 2
-			h = s + m
-			sublime.set_timeout(show, s)
-			sublime.set_timeout(hide, h)
+        for i in range(3):
+            m = 300
+            s = i * m * 2
+            h = s + m
+            sublime.set_timeout(show, s)
+            sublime.set_timeout(hide, h)
 
 class GsNewGoFileCommand(sublime_plugin.WindowCommand):
-	def run(self):
-		pkg_name = 'main'
-		view = gs.active_valid_go_view()
-		try:
-			basedir = gs.basedir_or_cwd(view and view.file_name())
-			for fn in os.listdir(basedir):
-				if fn.endswith('.go'):
-					name, _ = mg9.pkg_name(os.path.join(basedir, fn), '')
-					if name:
-						pkg_name = name
-						break
-		except Exception:
-			gs.error_traceback('GsNewGoFile')
+    def run(self):
+        pkg_name = 'main'
+        view = gs.active_valid_go_view()
+        try:
+            basedir = gs.basedir_or_cwd(view and view.file_name())
+            for fn in os.listdir(basedir):
+                if fn.endswith('.go'):
+                    name, _ = mg9.pkg_name(os.path.join(basedir, fn), '')
+                    if name:
+                        pkg_name = name
+                        break
+        except Exception:
+            gs.error_traceback('GsNewGoFile')
 
-		self.window.new_file().run_command('gs_create_new_go_file', {
-			'pkg_name': pkg_name,
-			'file_name': 'main.go',
-		})
+        self.window.new_file().run_command('gs_create_new_go_file', {
+            'pkg_name': pkg_name,
+            'file_name': 'main.go',
+        })
 
 class GsCreateNewGoFileCommand(sublime_plugin.TextCommand):
-	def run(self, edit, pkg_name, file_name):
-		view = self.view
-		view.set_name(file_name)
-		view.set_syntax_file(gs.tm_path('go'))
-		view.replace(edit, sublime.Region(0, view.size()), 'package %s\n' % pkg_name)
-		view.sel().clear()
-		view.sel().add(view.find(pkg_name, 0, sublime.LITERAL))
+    def run(self, edit, pkg_name, file_name):
+        view = self.view
+        view.set_name(file_name)
+        view.set_syntax_file(gs.tm_path('go'))
+        view.replace(edit, sublime.Region(0, view.size()), 'package %s\n' % pkg_name)
+        view.sel().clear()
+        view.sel().add(view.find(pkg_name, 0, sublime.LITERAL))
 
 class GsShowTasksCommand(sublime_plugin.WindowCommand):
-	def run(self):
-		ents = []
-		now = datetime.datetime.now()
-		m = {}
-		try:
-			tasks = gs.task_list()
-			ents.insert(0, ['', '%d active task(s)' % len(tasks)])
-			for tid, t in tasks:
-				cancel_text = ''
-				if t['cancel']:
-					cancel_text = ' (cancel task)'
-					m[len(ents)] = tid
+    def run(self):
+        ents = []
+        now = datetime.datetime.now()
+        m = {}
+        try:
+            tasks = gs.task_list()
+            ents.insert(0, ['', '%d active task(s)' % len(tasks)])
+            for tid, t in tasks:
+                cancel_text = ''
+                if t['cancel']:
+                    cancel_text = ' (cancel task)'
+                    m[len(ents)] = tid
 
-				ents.append([
-					'#%s %s%s' % (tid, t['domain'], cancel_text),
-					t['message'],
-					'started: %s' % t['start'],
-					'elapsed: %s' % (now - t['start']),
-				])
-		except:
-			ents = [['', 'Failed to gather active tasks']]
+                ents.append([
+                    '#%s %s%s' % (tid, t['domain'], cancel_text),
+                    t['message'],
+                    'started: %s' % t['start'],
+                    'elapsed: %s' % (now - t['start']),
+                ])
+        except:
+            ents = [['', 'Failed to gather active tasks']]
 
-		def cb(i, _):
-			gs.cancel_task(m.get(i, ''))
+        def cb(i, _):
+            gs.cancel_task(m.get(i, ''))
 
-		gs.show_quick_panel(ents, cb)
+        gs.show_quick_panel(ents, cb)
 
 class GsOpenHomePathCommand(sublime_plugin.WindowCommand):
-	def run(self, fn):
-		self.window.open_file(gs.home_path(fn))
+    def run(self, fn):
+        self.window.open_file(gs.home_path(fn))
 
 class GsOpenDistPathCommand(sublime_plugin.WindowCommand):
-	def run(self, fn):
-		self.window.open_file(gs.dist_path(fn))
+    def run(self, fn):
+        self.window.open_file(gs.dist_path(fn))
 
 class GsSanityCheckCommand(sublime_plugin.WindowCommand):
-	def run(self):
-		s = 'GoSublime Sanity Check\n\n%s' % '\n'.join(mg9.sanity_check_sl(mg9.sanity_check({}, True)))
-		gs.show_output('GoSublime', s)
+    def run(self):
+        s = 'GoSublime Sanity Check\n\n%s' % '\n'.join(mg9.sanity_check_sl(mg9.sanity_check({}, True)))
+        gs.show_output('GoSublime', s)
 
 class GsSetOutputPanelContentCommand(sublime_plugin.TextCommand):
-	def run(self, edit, content, syntax_file, scroll_end, replace):
-		panel = self.view
-		panel.set_read_only(False)
+    def run(self, edit, content, syntax_file, scroll_end, replace):
+        panel = self.view
+        panel.set_read_only(False)
 
-		if replace:
-			panel.replace(edit, sublime.Region(0, panel.size()), content)
-		else:
-			panel.insert(edit, panel.size(), content+'\n')
+        if replace:
+            panel.replace(edit, sublime.Region(0, panel.size()), content)
+        else:
+            panel.insert(edit, panel.size(), content+'\n')
 
-		panel.sel().clear()
-		pst = panel.settings()
-		pst.set("rulers", [])
-		pst.set("fold_buttons", True)
-		pst.set("fade_fold_buttons", False)
-		pst.set("gutter", False)
-		pst.set("line_numbers", False)
+        panel.sel().clear()
+        pst = panel.settings()
+        pst.set('rulers', [])
+        pst.set('fold_buttons', True)
+        pst.set('fade_fold_buttons', False)
+        pst.set('gutter', False)
+        pst.set('line_numbers', False)
 
-		if syntax_file:
-			if syntax_file == 'GsDoc':
-				panel.set_syntax_file(gs.tm_path('doc'))
-				panel.run_command("fold_by_level", { "level": 1 })
-			else:
-				panel.set_syntax_file(syntax_file)
+        if syntax_file:
+            if syntax_file == 'GsDoc':
+                panel.set_syntax_file(gs.tm_path('doc'))
+                panel.run_command('fold_by_level', { 'level': 1 })
+            else:
+                panel.set_syntax_file(syntax_file)
 
-		panel.set_read_only(True)
+        panel.set_read_only(True)
 
-		if scroll_end:
-			panel.show(panel.size())
+        if scroll_end:
+            panel.show(panel.size())
 
 class GsInsertContentCommand(sublime_plugin.TextCommand):
-	def run(self, edit, pos, content):
-		pos = int(pos) # un-fucking-believable
-		self.view.insert(edit, pos, content)
+    def run(self, edit, pos, content):
+        pos = int(pos) # un-fucking-believable
+        self.view.insert(edit, pos, content)
 
 class GsPatchImportsCommand(sublime_plugin.TextCommand):
-	def run(self, edit, pos, content, added_path=''):
-		pos = int(pos) # un-fucking-believable
-		view = self.view
-		dirty, err = gspatch.merge(view, pos, content, edit)
-		if err:
-			gs.notice_undo(DOMAIN, err, view, dirty)
-		elif dirty:
-			k = 'last_import_path.%s' % gs.view_fn(self.view)
-			if added_path:
-				gs.set_attr(k, added_path)
-			else:
-				gs.del_attr(k)
+    def run(self, edit, pos, content, added_path=''):
+        pos = int(pos) # un-fucking-believable
+        view = self.view
+        dirty, err = gspatch.merge(view, pos, content, edit)
+        if err:
+            gs.notice_undo(DOMAIN, err, view, dirty)
+        elif dirty:
+            k = 'last_import_path.%s' % gs.view_fn(self.view)
+            if added_path:
+                gs.set_attr(k, added_path)
+            else:
+                gs.del_attr(k)
 
 class GsGorenameCommand(sublime_plugin.TextCommand):
-	def is_enabled(self):
-		return self._is_go_source(self.view)
+    def is_enabled(self):
+        return self._is_go_source(self.view)
 
-	def run(self, edit):
-		view = self.view
+    def run(self, edit):
+        view = self.view
 
-		region = view.sel()[0]
+        region = view.sel()[0]
 
-		# If the current selection is empty, try to expand
-		# it to the word under the cursor
-		if region.empty():
-			region = view.word(region)
+        # If the current selection is empty, try to expand
+        # it to the word under the cursor
+        if region.empty():
+            region = view.word(region)
 
-		if region.empty(): 
-			sublime.message_dialog('Select an identifier you would like to rename and try again.')
-			return
+        if region.empty(): 
+            sublime.message_dialog('Select an identifier you would like to rename and try again.')
+            return
 
-		current_selection = view.substr(region)
-		filename = view.file_name()
-		
-		def on_done(new_name):
-			if new_name == current_selection:
-				return
+        current_selection = view.substr(region)
+        filename = view.file_name()
+        
+        def on_done(new_name):
+            if new_name == current_selection:
+                return
 
-			view.window().run_command("show_panel", {"panel": "console"})
+            view.window().run_command('show_panel', {'panel': 'console'})
 
-			gs.println(DOMAIN, 'Requested New Name: {0}'.format(new_name))
+            gs.println(DOMAIN, 'Requested New Name: {0}'.format(new_name))
 
-			offset =  '{0}:#{1}'.format(filename, region.begin())
-			command = ['gorename', '-v', '-offset', offset, '-to', new_name]
+            offset = '{0}:#{1}'.format(filename, region.begin())
+            command = ['gorename', '-v', '-offset', pipes.quote(str(offset)), '-to', new_name]
+            if platform.system() in ('Linux', 'Darwin'):
+                command = ['bash', '-c', 'GOPATH=${HOME}/go %s' % ' '.join(command)]
 
-			gs.println(DOMAIN, 'CMD: {0}'.format(' '.join(command)))
+            gs.println(DOMAIN, 'CMD: {0}'.format(' '.join(command)))
 
-			# Save all Go views
-			for win in sublime.windows():
-				for v in win.views():
-					if not self._is_go_source(v):
-						continue
-					v.run_command("save")
+            # Save all Go views
+            for win in sublime.windows():
+                for v in win.views():
+                    if self._is_go_source(v):
+                        v.run_command('save')
 
-			out = err = ""
-			try:
-				p = gs.popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-				out = p.communicate()[0]
-				gs.println('GsGorename', out)
+            try:
+                p = gs.popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                stdout, stderr = p.communicate()
+                if (stdout is None or len(stdout) == 0) and (stderr is None or len(stderr) == 0):
+                    gs.println('GsGorename', '<no output>')
+                else:
+                    if stdout is not None and len(stdout) > 0:
+                        gs.println('GsGorename stdout:', stdout)
+                    if stderr is not None and len(stdout) > 0:
+                        gs.println('GsGorename stderr:', stderr)
 
-				if p.returncode != 0:
-					raise OSError("GoRename failed")
+                if p.returncode != 0:
+                    raise OSError('GoRename failed, exited with status code %s' % p.returncode)
 
-			except Exception as e:
-				msg = gs.tbck.format_exc()
-				gs.println(DOMAIN, msg)
+            except Exception as e:
+                msg = gs.tbck.format_exc()
+                gs.println(DOMAIN, msg)
 
-		view.window().show_input_panel("New name:", current_selection, on_done, None, None)
+        view.window().show_input_panel('New name:', current_selection, on_done, None, None)
 
-	@staticmethod
-	def _is_go_source(view):
-		fn = view.file_name()
-		if fn:
-			scope_ok = fn.lower().endswith('.go')
-		else:
-			scope_ok = gs.is_go_source_view(view)
-		return scope_ok
+    @staticmethod
+    def _is_go_source(view):
+        fn = view.file_name()
+        if fn:
+            scope_ok = fn.lower().endswith('.go')
+        else:
+            scope_ok = gs.is_go_source_view(view)
+        return scope_ok
 

--- a/src/gosubli.me/margo/common.go
+++ b/src/gosubli.me/margo/common.go
@@ -169,7 +169,7 @@ func rootDirs(env map[string]string) []string {
 	} else if fn := os.Getenv("GOROOT"); fn != "" {
 		gorootBase = fn
 	}
-	goroot := filepath.Join(gorootBase, "src", "pkg")
+	goroot := filepath.Join(gorootBase, SrcPkg)
 
 	dirsSeen := map[string]bool{}
 	for _, fn := range filepath.SplitList(gopath) {

--- a/src/gosubli.me/margo/m_doc.go
+++ b/src/gosubli.me/margo/m_doc.go
@@ -184,7 +184,7 @@ func findUnderlyingObj(fset *token.FileSet, af *ast.File, pkg *ast.Package, pkgs
 		if obj := pkg.Scope.Lookup(id.Name); obj != nil {
 			return obj, pkg, pkgs
 		}
-		fn := filepath.Join(runtime.GOROOT(), "src", "pkg", "builtin")
+		fn := filepath.Join(runtime.GOROOT(), SrcPkg, "builtin")
 		if pkgBuiltin, _, err := parsePkg(fset, fn, parser.ParseComments); err == nil {
 			if obj := pkgBuiltin.Scope.Lookup(id.Name); obj != nil {
 				return obj, pkgBuiltin, pkgs

--- a/src/gosubli.me/margo/m_pkgpaths.go
+++ b/src/gosubli.me/margo/m_pkgpaths.go
@@ -40,7 +40,7 @@ func mPkgPathsRes(env map[string]string, exclude []string) map[string]map[string
 		}()
 	}
 
-	proc(filepath.Join(goroot, "src", "pkg"))
+	proc(filepath.Join(goroot, SrcPkg))
 	for _, p := range gopaths {
 		proc(filepath.Join(p, "src"))
 	}

--- a/src/gosubli.me/margo/srcpkg.go
+++ b/src/gosubli.me/margo/srcpkg.go
@@ -1,0 +1,9 @@
+// +build !go1.4
+
+package main
+
+import (
+	"path/filepath"
+)
+
+const SrcPkg = "src" + string(filepath.Separator) + "pkg"

--- a/src/gosubli.me/margo/srcpkg1.4.go
+++ b/src/gosubli.me/margo/srcpkg1.4.go
@@ -1,0 +1,5 @@
+// +build go1.4
+
+package main
+
+const SrcPkg = "src"


### PR DESCRIPTION
Merged latest DisposaBoy master, and updated the python script so that `gorename' now works out of the box for the common/default case of a`$GOPATH`located under`$HOME/go`.

Also added default keybinding ctrl-shift-r (super-shift-r on OSX).
